### PR TITLE
Remove Pull Approve Config file

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,2 +1,0 @@
----
-extends: hellofresh


### PR DESCRIPTION
Since Pull Approve is no longer in use, this PR removes its config file