### PR TITLE
Update ansible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.8.1
+ansible==2.8.3
 molecule
 docker-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.7.10
+ansible==2.8.1
 molecule
 docker-py


### PR DESCRIPTION
## Fix for CVE-2019-10156 

Vulnerable versions: >= 2.7.0, < 2.7.12
Patched version: 2.7.12

A flaw was discovered in the way Ansible templating was implemented in versions before 2.6.18, 2.7.12 and 2.8.2, causing the possibility of information disclosure through unexpected variable substitution. By taking advantage of unintended variable substitution the content of any variable may be disclosed.