### PR TITLE
Add certificate configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Use their name later within the `ldap_tls_cacert` parameter.
     certificates:
       - my_root_ca.crt
 
-Options that are listed in `sssd_domain_defaults` will allways be present in `sssd.conf`,
+Options that are listed in `sssd_domain_defaults` will always be present in `sssd.conf`,
 other options can be omitted.
 
 Dependencies

--- a/README.md
+++ b/README.md
@@ -79,11 +79,12 @@ Role supports configuring multiple domains using following syntax:
         ldap_group_gid_number:
         ldap_group_member:
         ldap_tls_cacert:
-    
+
+Add certificates from your files directory as you wish.
+Use their name later within the `ldap_tls_cacert` parameter.
+
     certificates:
       - my_root_ca.crt
-
-(**Note: you have to put a file with the certificate name inside your files directory, to make the parameters ldap_tls_cacert and certificates work**)
 
 Options that are listed in `sssd_domain_defaults` will allways be present in `sssd.conf`,
 other options can be omitted.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ feel free to create pull requests. You can find available options in `defaults/m
 
 Some default values for domain specific configuration options are:
 
+
     sssd_domain_defaults:
       min_id: 1
       max_id: 0
@@ -77,6 +78,12 @@ Role supports configuring multiple domains using following syntax:
         ldap_group_name:
         ldap_group_gid_number:
         ldap_group_member:
+        ldap_tls_cacert:
+    
+    certificates:
+      - my_root_ca.crt
+
+(**Note: you have to put a file with the certificate name inside your files directory, to make the parameters ldap_tls_cacert and certificates work**)
 
 Options that are listed in `sssd_domain_defaults` will allways be present in `sssd.conf`,
 other options can be omitted.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+certificate_base_path: /usr/local/share/ca-certificates
+
 sssd_defaults:
   # Debug level for:
   # Fatal failures, Critical failures, Serious failures

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -1,0 +1,13 @@
+---
+- name: ensure certificate directory exists
+  file:
+    path: '{{ certificate_base_path }}'
+    state: directory
+
+- name: copy certificates
+  copy:
+    src: '{{ item }}'
+    dest: '{{ certificate_base_path }}/{{ item }}'
+  loop: '{{ certificates }}'
+  notify:
+    - restart sssd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,9 @@
 
 - include: packages.yml
 
+- include_tasks: certificates.yml
+  when: certificates is defined
+
 - include: sssd.yml
 
 - include: nsswitch.yml

--- a/templates/sssd.conf.j2
+++ b/templates/sssd.conf.j2
@@ -89,5 +89,8 @@ ldap_group_gid_number = {{ domain.ldap_group_gid_number }}
 {% if domain.ldap_group_member is defined %}
 ldap_group_member = {{ domain.ldap_group_member }}
 {% endif %}
+{% if domain.ldap_tls_cacert is defined %}
+ldap_tls_cacert = {{ domain.ldap_tls_cacert }}
+{% endif %}
 
 {% endfor %}

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,10 @@
+---
+sssd_ldap_packages:
+  - sssd
+  - sssd-ldap
+  - sudo
+  - openssh-server
+  - libnss-sss
+  - libpam-sss
+
+sssd_ldap_ssh_service: ssh


### PR DESCRIPTION
Adding the following variables:

ldap_tls_cacert

I also included a new file to make the role work in Debian.
This can however not automatically be tested, as molecule only supports CentOS and Ubuntu as far as I know. - It works on Debian Buster though.

I think we can merge this and flag Debian as not tested (if at all).