### PR TITLE
Add libsss-sudo library

### DIFF
--- a/vars/ubuntu.yml
+++ b/vars/ubuntu.yml
@@ -6,5 +6,6 @@ sssd_ldap_packages:
   - openssh-server
   - libnss-sss
   - libpam-sss
+  - libsss-sudo
 
 sssd_ldap_ssh_service: ssh


### PR DESCRIPTION
After adding sudo schema:
```ldif
attributetype ( 1.3.6.1.4.1.15953.9.1.1
   NAME 'sudoUser'
   DESC 'User(s) who may  run sudo'
   EQUALITY caseExactMatch
   SUBSTR caseExactSubstringsMatch
   SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )

attributetype ( 1.3.6.1.4.1.15953.9.1.2
  NAME ‘sudoHost’
  DESC ‘Host(s) who may run sudo’
  EQUALITY caseExactIA5Match
  SUBSTR caseExactIA5SubstringsMatch
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )

attributetype ( 1.3.6.1.4.1.15953.9.1.3
  NAME ‘sudoCommand’
  DESC ‘Command(s) to be executed by sudo’
  EQUALITY caseExactIA5Match
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )

attributetype ( 1.3.6.1.4.1.15953.9.1.4
  NAME ‘sudoRunAs’
  DESC ‘User(s) impersonated by sudo’
  EQUALITY caseExactIA5Match
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )

attributetype ( 1.3.6.1.4.1.15953.9.1.5
  NAME ‘sudoOption’
  DESC ‘Options(s) followed by sudo’
  EQUALITY caseExactIA5Match
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.26 )

attributetype ( 1.3.6.1.4.1.15953.9.1.6
  NAME ‘sudoRunAsUser’
  DESC ‘User(s) impersonated by sudo’
  EQUALITY caseExactMatch
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )

attributetype ( 1.3.6.1.4.1.15953.9.1.7
  NAME ‘sudoRunAsGroup’
  DESC ‘Group(s) impersonated by sudo’
  EQUALITY caseExactMatch
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15 )

attributetype ( 1.3.6.1.4.1.15953.9.1.8
  NAME ‘sudoNotBefore’
  DESC ‘Start of time interval for which the entry is valid’
  EQUALITY generalizedTimeMatch
  ORDERING generalizedTimeOrderingMatch
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )

attributetype ( 1.3.6.1.4.1.15953.9.1.9
  NAME ‘sudoNotAfter’
  DESC ‘End of time interval for which the entry is valid’
  EQUALITY generalizedTimeMatch
  ORDERING generalizedTimeOrderingMatch
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.24 )

attributetype ( 1.3.6.1.4.1.15953.9.1.10
  NAME ‘sudoOrder’
  DESC ‘an integer to order the sudoRole entries’
  EQUALITY integerMatch
  ORDERING integerOrderingMatch
  SYNTAX 1.3.6.1.4.1.1466.115.121.1.27 )

objectclass ( 1.3.6.1.4.1.15953.9.2.1 NAME ‘sudoRole’ SUP top STRUCTURAL
  DESC ‘Sudoer Entries’
  MUST ( cn )
  MAY ( sudoUser $ sudoHost $ sudoCommand $ sudoRunAs $ sudoRunAsUser $
  sudoRunAsGroup $ sudoOption $ sudoNotBefore $ sudoNotAfter $
  sudoOrder $ description )
  )
```

And adding the sudo objects in OpenLDAP:
```ldif
dn: ou=SUDOers,dc=example,dc=com
objectClass: organizationalUnit
objectClass: top
ou: people

dn: cn=defaults,ou=SUDOers,dc=example,dc=com
objectClass: top
objectClass: sudoRole
cn: defaults
description: Default sudoOption's go here
sudoOption: env_keep+=SSH_AUTH_SOCK

dn: cn=sysadmin,ou=SUDOers,dc=example,dc=com
objectClass: sudoRole
objectClass: top
cn: sysadmin
sudoUser: testuser1
sudoHost: ALL
sudoRunAsUser: ALL
sudoRunAsGroup: ALL
sudoCommand: ALL
```

I recieved the following error when attempting to sudo:
```
sudo: unable to load /usr/lib/x86_64-linux-gnu/libsss_sudo.so: (null)
sudo: unable to initialize SSS source. Is SSSD installed on your machine?
```